### PR TITLE
fix brackets in regular expressions of parameters

### DIFF
--- a/src/ApiRoute.php
+++ b/src/ApiRoute.php
@@ -326,6 +326,7 @@ class ApiRoute extends ApiRouteSpec implements IRouter
 
 			$regex = isset($parameter['requirement']) ? $parameter['requirement'] : '\w+';
 			$has_default = array_key_exists('default', $parameter);
+			$regex = preg_replace('~\(~', '(?:', $regex);
 
 			if ($has_default) {
 				$order[] = $placeholder;


### PR DESCRIPTION
Example code in nette `RouteFactory::createRouter()`: 
```
$router[] = new ApiRoute('/api/<apiVersion>/Book/<id>/<column>[/<columnAction>]', 'ApiBook', [
			'parameters' => [
				'apiVersion' => ['requirement' => 'v\d+(\.\d+)*'],
				'id' => ['requirement' => '\d+'],
				'column' => ['requirement' => '\w+'],
				'columnAction' => ['requirement' => '\w+'],
			],
			'priority' => 1,
		]);
```
Fix brackets in regular expressions of parameters. In Example parameter `apiVersion`.