### PR TITLE
bumped doctrine annotations version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 		"nette/reflection": "^2.3|^2.4",
 		"doctrine/cache": "~1.6.0",
 		"doctrine/annotations": "~1.2.7"
+		"doctrine/annotations": "~1.3",
 	},
 	"require-dev": {
 		"nette/tester": "~1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"nette/di": "^2.3|^2.4",
 		"nette/reflection": "^2.3|^2.4",
 		"doctrine/cache": "~1.6.0",
-		"doctrine/annotations": "~1.2.0"
+		"doctrine/annotations": "~1.2.7"
 	},
 	"require-dev": {
 		"nette/tester": "~1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
 		"nette/di": "^2.3|^2.4",
 		"nette/reflection": "^2.3|^2.4",
 		"doctrine/cache": "~1.6.0",
-		"doctrine/annotations": "~1.2.7"
-		"doctrine/annotations": "~1.3",
+		"doctrine/annotations": "~1.3"
 	},
 	"require-dev": {
 		"nette/tester": "~1.6.1",


### PR DESCRIPTION
Bumped doctrine annotations version so it doesn't have conflict when install to project which contains https://github.com/Roave/SecurityAdvisories ( it's meant to protect you from installing unsupported package or package with known security issue).