### PR TITLE
Doctrine cache version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
 	},
 	"require": {
 		"php": ">= 7.1.0",
-		"nette/http" : "^2.3|^2.4",
-		"nette/utils": "^2.3|^2.4",
-		"nette/application": "^2.3|^2.4",
-		"nette/di": "^2.3|^2.4",
-		"nette/reflection": "^2.3|^2.4",
+		"nette/http" : "^2.3",
+		"nette/utils": "^2.3",
+		"nette/application": "^2.3",
+		"nette/di": "^2.3",
+		"nette/reflection": "^2.3",
 		"doctrine/cache": "^1.6",
 		"doctrine/annotations": "~1.3"
 	},
 	"require-dev": {
 		"nette/tester": "~1.6.1",
 		"mockery/mockery": "~0.9",
-		"tracy/tracy": "^2.3|^2.4"
+		"tracy/tracy": "^2.3"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"nette/application": "^2.3|^2.4",
 		"nette/di": "^2.3|^2.4",
 		"nette/reflection": "^2.3|^2.4",
-		"doctrine/cache": "~1.6.0",
+		"doctrine/cache": "^1.6",
 		"doctrine/annotations": "~1.3"
 	},
 	"require-dev": {


### PR DESCRIPTION
removed unnecessary "|^2.4" and making doctrine/cache version requirement less strict