### PR TITLE
unify syntax in readmes

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,7 +6,7 @@ RESTful Router for your Apis in Nette Framework - created either directly or via
 
 ApiRouter is available on composer:
 
-```
+```bash
 composer require contributte/api-router
 ```
 


### PR DESCRIPTION
Polished docs
- use 4 spaces in CSS, in JS, in HTML and in Latte
- use tab in NEON and in PHP
- neon highlighting syntax
- normalized filename of Readmes
- typos