### PR TITLE
Fix for str_replace(): Argument #2 ($replace) must be of type array|string, int given on PHP 8

### DIFF
--- a/src/ApiRoute.php
+++ b/src/ApiRoute.php
@@ -386,7 +386,7 @@ class ApiRoute extends ApiRouteSpec implements Router
 
 		foreach ($parameters as $name => $value) {
 			if (strpos($path, "<{$name}>") !== false && $value !== null) {
-				$path = str_replace("<{$name}>", $value, $path);
+				$path = str_replace("<{$name}>", (string) $value, $path);
 
 				unset($parameters[$name]);
 			}


### PR DESCRIPTION
I've come across a problem with PHP8 and declare(strict_types=1); -- not sure what causes it exactly, but I wasn't able to make a route with 2 params like this:

```
$list[] = new ApiRoute('/api/conversion/save/<queueHash>/<elementId>', 'Conversion', [
    'methods' => ['GET']
]);
```

The application always threw an error `str_replace(): Argument #2 ($replace) must be of type array|string, int given`. I solved this by casting the $replace variable to string. I hope this helps someone.