### PR TITLE
Missing HEAD method

### DIFF
--- a/src/ApiRoute.php
+++ b/src/ApiRoute.php
@@ -40,6 +40,7 @@ class ApiRoute extends ApiRouteSpec implements Router
 		'DELETE' => false,
 		'OPTIONS' => false,
 		'PATCH' => false,
+		'HEAD' => false,
 	];
 
 	/**
@@ -52,6 +53,7 @@ class ApiRoute extends ApiRouteSpec implements Router
 		'DELETE' => 'delete',
 		'OPTIONS' => 'options',
 		'PATCH' => 'patch',
+		'HEAD' => 'head',
 	];
 
 	/**


### PR DESCRIPTION
While calling HEAD method API router throws Notice: E_NOTICE: Undefined index: HEAD in /vendor/contributte/api-router/src/ApiRoute.php:323

HEAD is important for checking for chages in response body without download it and save data transfers over network etc.  https://www.rfc-editor.org/rfc/rfc7231#section-4.3.2