### PR TITLE
Revert "ApiRoute: kick-off basepath"

### DIFF
--- a/src/ApiRoute.php
+++ b/src/ApiRoute.php
@@ -248,16 +248,7 @@ class ApiRoute extends ApiRouteSpec implements Router
 
 		$url = $httpRequest->getUrl();
 
-		// Resolve base path
-		$basePath = $url->getBasePath();
-		if (strncmp($url->getPath(), $basePath, strlen($basePath)) !== 0) {
-			return null;
-		}
-
-		$path = substr($url->getPath(), strlen($basePath));
-
-		// Ensure start with /
-		$path = '/' . ltrim($path, '/');
+		$path = $url->getPath();
 
 		/**
 		 * Build path mask

--- a/tests/Cases/ApiRouteTest.php
+++ b/tests/Cases/ApiRouteTest.php
@@ -93,107 +93,79 @@ final class ApiRouteTest extends TestCase
 	public function testMatchUrl(): void
 	{
 		$route = new ApiRoute('/users/', 'U');
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
 		$route = new ApiRoute('/users', 'U');
-		$u = new UrlScript('http://foo.com/users/', '/');
+		$u = new UrlScript('http://foo.com/users/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
 		$route = new ApiRoute('/users[/]', 'U');
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
 		$route = new ApiRoute('/users[/]', 'U');
-		$u = new UrlScript('http://foo.com/users/', '/');
+		$u = new UrlScript('http://foo.com/users/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
-	}
-
-
-	public function testMatchUrlWithBasePath(): void
-	{
-		$route = new ApiRoute('/api/ping', 'U');
-		$u = new UrlScript('http://foo.com/api-project/api/ping', '/api-project/');
-		$r = new Request($u);
-
-		Assert::notSame(null, $route->match($r));
-
-		$route = new ApiRoute('/api/ping/', 'U');
-		$u = new UrlScript('http://foo.com/api-project/api/ping/', '/api-project/');
-		$r = new Request($u);
-
-		Assert::notSame(null, $route->match($r));
-
-		$route = new ApiRoute('/api/ping', 'U');
-		$u = new UrlScript('http://foo.com/api-project/api/fake', '/api-project/');
-		$r = new Request($u);
-
-		Assert::same(null, $route->match($r));
-
-		$route = new ApiRoute('/api/ping', 'U');
-		$u = new UrlScript('http://foo.com/api-project/fake', '/api-project/');
-		$r = new Request($u);
-
-		Assert::same(null, $route->match($r));
 	}
 
 	public function testMatchParameters(): void
 	{
 		$route = new ApiRoute('/users/<id>', 'U');
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
 		$route = new ApiRoute('/users/<id>', 'U');
-		$u = new UrlScript('http://foo.com/users/aaaa', '/');
+		$u = new UrlScript('http://foo.com/users/aaaa');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same('aaaa', $appRq['id']);
 
 		$route = new ApiRoute('/users[/<id>]', 'U');
-		$u = new UrlScript('http://foo.com/users/aaaa', '/');
+		$u = new UrlScript('http://foo.com/users/aaaa');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same('aaaa', $appRq['id']);
 
 		$route = new ApiRoute('/users[/<id>]', 'U');
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same(null, $appRq['id']);
 
 		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
 		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
-		$u = new UrlScript('http://foo.com/users/a', '/');
+		$u = new UrlScript('http://foo.com/users/a');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
 		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
-		$u = new UrlScript('http://foo.com/users/l-p', '/');
+		$u = new UrlScript('http://foo.com/users/l-p');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
 		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
-		$u = new UrlScript('http://foo.com/users/l-p/8/aa', '/');
+		$u = new UrlScript('http://foo.com/users/l-p/8/aa');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -203,7 +175,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('aa', $appRq['a']);
 
 		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
-		$u = new UrlScript('http://foo.com/users/l-p/8/aa?bubla=a', '/');
+		$u = new UrlScript('http://foo.com/users/l-p/8/aa?bubla=a');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -212,7 +184,7 @@ final class ApiRouteTest extends TestCase
 
 		$route = new ApiRoute('/users[/<id>][/<foo>][/<bar>]', 'U');
 
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -220,7 +192,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same(null, $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1', '/');
+		$u = new UrlScript('http://foo.com/users/1');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -228,7 +200,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same(null, $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1/foo', '/');
+		$u = new UrlScript('http://foo.com/users/1/foo');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -236,7 +208,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('foo', $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1/foo/bar', '/');
+		$u = new UrlScript('http://foo.com/users/1/foo/bar');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -246,7 +218,7 @@ final class ApiRouteTest extends TestCase
 
 		$route = new ApiRoute('/users[/<id>[/<foo>[/<bar>]]]', 'U');
 
-		$u = new UrlScript('http://foo.com/users', '/');
+		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -254,7 +226,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same(null, $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1', '/');
+		$u = new UrlScript('http://foo.com/users/1');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -262,7 +234,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same(null, $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1/foo', '/');
+		$u = new UrlScript('http://foo.com/users/1/foo');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
@@ -270,7 +242,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('foo', $appRq['foo']);
 		Assert::same(null, $appRq['bar']);
 
-		$u = new UrlScript('http://foo.com/users/1/foo/bar', '/');
+		$u = new UrlScript('http://foo.com/users/1/foo/bar');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));


### PR DESCRIPTION
Hello, I'd like to propose the revert of basepath changes introduced in 4.2 as they carry BC break that can't by bypassed by any means. 

This is follow-up to the open issue https://github.com/contributte/api-router/issues/52