### PR TITLE
Replace deprecated annotations with attributes

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -50,7 +50,7 @@ use Contributte\ApiRouter\ApiRoute;
  * API for managing users
  */
 #[ApiRoute(
-	'/api-router/api/users[/<id>]',
+	path: '/api-router/api/users[/<id>]',
 	parameters: [
 		'id' => [
 			'requirement' => '\d+',
@@ -67,7 +67,7 @@ class UsersController extends Presenter
 	 * Get user detail
 	 */
 	#[ApiRoute(
-		'/api-router/api/users/<id>[/<foo>-<bar>]',
+		path: '/api-router/api/users/<id>[/<foo>-<bar>]',
 		parameters: [
 			'id' => [
 				'requirement' => '\d+',
@@ -122,18 +122,18 @@ class RouterFactory
 		 * 	PUT     => UsersPresenter::actionUpdate()
 		 * 	DELETE  => UsersPresenter::actionDelete()
 		 */
-		$router[] = new ApiRoute('/hello', 'Users');
+		$router[] = new ApiRoute(path: '/hello', presenter: 'Users');
 
 		/**
 		 * Custom matching:
 		 * 	GET  => UsersPresenter::actionSuperRead()
 		 * 	POST => UsersPresenter::actionCreate()
 		 */
-		$router[] = new ApiRoute('/hello', 'ApiRouter', methods: ['GET' => 'superRead', 'POST']);
+		$router[] = new ApiRoute(path: '/hello', presenter: 'ApiRouter', methods: ['GET' => 'superRead', 'POST']);
 
 		$router[] = new ApiRoute(
-			'/api-router/api/users[/<id>]',
-			'Resources:Users',
+			path: '/api-router/api/users[/<id>]',
+			presenter: 'Resources:Users',
 			parameters: [
 				'id' => ['requirement' => '\d+', 'default' => 10],
 			],
@@ -141,8 +141,8 @@ class RouterFactory
 		);
 
 		$router[] = new ApiRoute(
-			'/api-router/api/users/<id>[/<foo>-<bar>]',
-			'Resources:Users',
+			path: '/api-router/api/users/<id>[/<foo>-<bar>]',
+			presenter: 'Resources:Users',
 			parameters: [
 				'id' => ['requirement' => '\d+'],
 			],
@@ -150,7 +150,7 @@ class RouterFactory
 		);
 
 		# Disable basePath detection
-		$route = new ApiRoute('/api-router/api/users', 'Resources:Users');
+		$route = new ApiRoute(path: '/api-router/api/users', presenter: 'Resources:Users');
 		$route->setAutoBasePath(false);
 		$router[] = $route;
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -4,7 +4,7 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
-    + [Using annotation](#using-annotation)
+    + [Using attributes](#using-attributes)
     + [Using Nette Router](#using-nette-router)
     + [Api documentation](#api-documentation)
 - [Examples](#examples)
@@ -36,9 +36,9 @@ services:
 	- App\Controllers\PingController
 ```
 
-### Using annotation
+### Using attributes
 
-Example of used annotations. Don't forget to import `Contributte\ApiRouter\ApiRoute`, it's required by [doctrine/annotations](https://github.com/doctrine/annotations).
+Example of used attributes. Don't forget to import `Contributte\ApiRouter\ApiRoute`.
 
 ```php
 namespace App\ResourcesModule\Presenters;
@@ -48,48 +48,46 @@ use Contributte\ApiRouter\ApiRoute;
 
 /**
  * API for managing users
- *
- * @ApiRoute(
- * 	"/api-router/api/users[/<id>]",
- * 	parameters={
- * 		"id"={
- * 			"requirement": "\d+",
- * 			"default": 10
- * 		}
- * 	},
- *  priority=1,
- *  presenter="Resources:Users"
- * )
  */
+#[ApiRoute(
+	'/api-router/api/users[/<id>]',
+	parameters: [
+		'id' => [
+			'requirement' => '\d+',
+			'default' => 10,
+		],
+	],
+	priority: 1,
+	presenter: 'Resources:Users',
+)]
 class UsersController extends Presenter
 {
 
 	/**
 	 * Get user detail
-	 *
-	 * @ApiRoute(
-	 * 	"/api-router/api/users/<id>[/<foo>-<bar>]",
-	 * 	parameters={
-	 * 		"id"={
-	 * 			"requirement": "\d+"
-	 * 		}
-	 * 	},
-	 * 	method="GET"
-	 * )
 	 */
-	public function actionRead($id, $foo = NULL, $bar = NULL)
+	#[ApiRoute(
+		'/api-router/api/users/<id>[/<foo>-<bar>]',
+		parameters: [
+			'id' => [
+				'requirement' => '\d+',
+			],
+		],
+		method: 'GET',
+	)]
+	public function actionRead(int $id, ?string $foo = null, ?string $bar = null): void
 	{
 		$this->sendJson(['id' => $id, 'foo' => $foo, 'bar' => $bar]);
 	}
 
 
-	public function actionUpdate($id)
+	public function actionUpdate(int $id): void
 	{
 		$this->sendJson(['id' => $id]);
 	}
 
 
-	public function actionDelete($id)
+	public function actionDelete(int $id): void
 	{
 		$this->sendJson(['id' => $id]);
 	}
@@ -105,15 +103,15 @@ If you don't want to create route with DELETE method, simply remove the `UsersPr
 ```php
 namespace App;
 
-use Contributte\ApiRouter\ApiRoute;use Nette;use Nette\Application\Routers\Route;use Nette\Application\Routers\RouteList;
+use Contributte\ApiRouter\ApiRoute;
+use Nette;
+use Nette\Application\Routers\Route;
+use Nette\Application\Routers\RouteList;
 
 class RouterFactory
 {
 
-	/**
-	 * @return Nette\Application\IRouter
-	 */
-	public function createRouter()
+	public function createRouter(): Nette\Routing\RouteList
 	{
 		$router = new RouteList;
 
@@ -131,23 +129,25 @@ class RouterFactory
 		 * 	GET  => UsersPresenter::actionSuperRead()
 		 * 	POST => UsersPresenter::actionCreate()
 		 */
-		$router[] = new ApiRoute('/hello', 'ApiRouter', [
-			'methods' => ['GET' => 'superRead', 'POST'],
-		]);
+		$router[] = new ApiRoute('/hello', 'ApiRouter', methods: ['GET' => 'superRead', 'POST']);
 
-		$router[] = new ApiRoute('/api-router/api/users[/<id>]', 'Resources:Users', [
-			'parameters' => [
+		$router[] = new ApiRoute(
+			'/api-router/api/users[/<id>]',
+			'Resources:Users',
+			parameters: [
 				'id' => ['requirement' => '\d+', 'default' => 10],
 			],
-			'priority' => 1,
-		]);
+			priority: 1,
+		);
 
-		$router[] = new ApiRoute('/api-router/api/users/<id>[/<foo>-<bar>]', 'Resources:Users', [
-			'parameters' => [
+		$router[] = new ApiRoute(
+			'/api-router/api/users/<id>[/<foo>-<bar>]',
+			'Resources:Users',
+			parameters: [
 				'id' => ['requirement' => '\d+'],
 			],
-			'priority' => 1,
-		]);
+			priority: 1,
+		);
 
 		# Disable basePath detection
 		$route = new ApiRoute('/api-router/api/users', 'Resources:Users');

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "contributte/api-router",
   "type": "library",
-  "description": "RESTful Router for your Apis in Nette Framework - created either directly or via annotation",
+  "description": "RESTful Router for your Apis in Nette Framework - created either directly or via attributes",
   "keywords": [
     "rest",
     "api",
@@ -28,9 +28,7 @@
     "nette/http": "^3.3.0",
     "nette/application": "^3.2.5",
     "nette/di": "^3.2.2",
-    "contributte/utils": "^0.6.0 || ^0.7.0",
-    "symfony/cache": "^7.0.7",
-    "doctrine/annotations": "^2.0.1"
+    "contributte/utils": "^0.6.0 || ^0.7.0"
   },
   "require-dev": {
     "contributte/qa": "^0.4",

--- a/tests/Cases/ApiRouteSpecTest.php
+++ b/tests/Cases/ApiRouteSpecTest.php
@@ -19,7 +19,7 @@ final class ApiRouteSpecTest extends TestCase
 	{
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users', 'Users', parameters: ['id' => ['type' => 'integer']]);
+				new ApiRoute(path: '/users', presenter: 'Users', parameters: ['id' => ['type' => 'integer']]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'Parameter <id> is not present in the url mask'
@@ -27,7 +27,7 @@ final class ApiRouteSpecTest extends TestCase
 
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users/<id>', 'Users', parameters: ['id' => ['foo' => 'integer']]);
+				new ApiRoute(path: '/users/<id>', presenter: 'Users', parameters: ['id' => ['foo' => 'integer']]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'You cat set only these description informations: [requirement, type, description, default] - "foo" given'
@@ -35,7 +35,7 @@ final class ApiRouteSpecTest extends TestCase
 
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users/<id>', 'Users', parameters: ['id' => ['type' => []]]);
+				new ApiRoute(path: '/users/<id>', presenter: 'Users', parameters: ['id' => ['type' => []]]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'You cat set only scalar parameters informations (key [type])'
@@ -44,7 +44,7 @@ final class ApiRouteSpecTest extends TestCase
 
 	public function testTags(): void
 	{
-		$route = new ApiRoute('/u', 'Users', tags: ['public', 'secured' => '#e74c3c']);
+		$route = new ApiRoute(path: '/u', presenter: 'Users', tags: ['public', 'secured' => '#e74c3c']);
 
 		Assert::same(['public' => '#9b59b6', 'secured' => '#e74c3c'], $route->getTags());
 	}

--- a/tests/Cases/ApiRouteSpecTest.php
+++ b/tests/Cases/ApiRouteSpecTest.php
@@ -15,22 +15,11 @@ require __DIR__ . '/../bootstrap.php';
 final class ApiRouteSpecTest extends TestCase
 {
 
-	public function testConstructor(): void
-	{
-		Assert::exception(
-			function (): void {
-				new ApiRoute('/users', 'Users', ['foo' => 'boo']);
-			},
-			ApiRouteWrongPropertyException::class,
-			'Unknown property "foo" on annotation "Contributte\ApiRouter\ApiRoute"'
-		);
-	}
-
 	public function testParameters(): void
 	{
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users', 'Users', ['parameters' => ['id' => ['type' => 'integer']]]);
+				new ApiRoute('/users', 'Users', parameters: ['id' => ['type' => 'integer']]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'Parameter <id> is not present in the url mask'
@@ -38,7 +27,7 @@ final class ApiRouteSpecTest extends TestCase
 
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users/<id>', 'Users', ['parameters' => ['id' => ['foo' => 'integer']]]);
+				new ApiRoute('/users/<id>', 'Users', parameters: ['id' => ['foo' => 'integer']]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'You cat set only these description informations: [requirement, type, description, default] - "foo" given'
@@ -46,7 +35,7 @@ final class ApiRouteSpecTest extends TestCase
 
 		Assert::exception(
 			function (): void {
-				new ApiRoute('/users/<id>', 'Users', ['parameters' => ['id' => ['type' => []]]]);
+				new ApiRoute('/users/<id>', 'Users', parameters: ['id' => ['type' => []]]);
 			},
 			ApiRouteWrongPropertyException::class,
 			'You cat set only scalar parameters informations (key [type])'
@@ -55,7 +44,7 @@ final class ApiRouteSpecTest extends TestCase
 
 	public function testTags(): void
 	{
-		$route = new ApiRoute('/u', 'Users', ['tags' => ['public', 'secured' => '#e74c3c']]);
+		$route = new ApiRoute('/u', 'Users', tags: ['public', 'secured' => '#e74c3c']);
 
 		Assert::same(['public' => '#9b59b6', 'secured' => '#e74c3c'], $route->getTags());
 	}

--- a/tests/Cases/ApiRouteTest.php
+++ b/tests/Cases/ApiRouteTest.php
@@ -23,9 +23,7 @@ final class ApiRouteTest extends TestCase
 
 		Assert::same(['POST', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'], $route->getMethods());
 
-		$route = new ApiRoute('/u', 'U', [
-			'methods' => ['POST' => 'create'],
-		]);
+		$route = new ApiRoute('/u', 'U', methods: ['POST' => 'create']);
 
 		Assert::same(['POST'], $route->getMethods());
 
@@ -77,13 +75,13 @@ final class ApiRouteTest extends TestCase
 
 	public function testMatchMethods(): void
 	{
-		$route = new ApiRoute('/users', 'U', ['methods' => ['POST' => 'create']]);
+		$route = new ApiRoute('/users', 'U', methods: ['POST' => 'create']);
 		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u, [], [], [], [], 'GET');
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users', 'U', ['methods' => ['GET' => 'read']]);
+		$route = new ApiRoute('/users', 'U', methods: ['GET' => 'read']);
 		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u, [], [], [], [], 'POST');
 

--- a/tests/Cases/ApiRouteTest.php
+++ b/tests/Cases/ApiRouteTest.php
@@ -19,11 +19,11 @@ final class ApiRouteTest extends TestCase
 
 	public function testActionsMethods(): void
 	{
-		$route = new ApiRoute('/u', 'U');
+		$route = new ApiRoute(path: '/u', presenter: 'U');
 
 		Assert::same(['POST', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'PATCH', 'HEAD'], $route->getMethods());
 
-		$route = new ApiRoute('/u', 'U', methods: ['POST' => 'create']);
+		$route = new ApiRoute(path: '/u', presenter: 'U', methods: ['POST' => 'create']);
 
 		Assert::same(['POST'], $route->getMethods());
 
@@ -38,7 +38,7 @@ final class ApiRouteTest extends TestCase
 
 	public function testPlacehodlerParameters(): void
 	{
-		$route = new ApiRoute('/u/<id>[/<l>-<r>/<aa>]/<a>', 'U');
+		$route = new ApiRoute(path: '/u/<id>[/<l>-<r>/<aa>]/<a>', presenter: 'U');
 
 		Assert::same(['id', 'l', 'r', 'aa', 'a'], $route->getPlacehodlerParameters());
 		Assert::same(['id', 'a'], $route->getRequiredParams());
@@ -52,7 +52,7 @@ final class ApiRouteTest extends TestCase
 		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u, [], [], [], $headers, $method);
 
-		$route = new ApiRoute('/users', 'U');
+		$route = new ApiRoute(path: '/users', presenter: 'U');
 
 		Assert::same('GET', $route->resolveMethod($r));
 
@@ -75,13 +75,13 @@ final class ApiRouteTest extends TestCase
 
 	public function testMatchMethods(): void
 	{
-		$route = new ApiRoute('/users', 'U', methods: ['POST' => 'create']);
+		$route = new ApiRoute(path: '/users', presenter: 'U', methods: ['POST' => 'create']);
 		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u, [], [], [], [], 'GET');
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users', 'U', methods: ['GET' => 'read']);
+		$route = new ApiRoute(path: '/users', presenter: 'U', methods: ['GET' => 'read']);
 		$u = new UrlScript('http://foo.com/users');
 		$r = new Request($u, [], [], [], [], 'POST');
 
@@ -90,25 +90,25 @@ final class ApiRouteTest extends TestCase
 
 	public function testMatchUrl(): void
 	{
-		$route = new ApiRoute('/users/', 'U');
+		$route = new ApiRoute(path: '/users/', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users', 'U');
+		$route = new ApiRoute(path: '/users', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/', '/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users[/]', 'U');
+		$route = new ApiRoute(path: '/users[/]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
-		$route = new ApiRoute('/users[/]', 'U');
+		$route = new ApiRoute(path: '/users[/]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/', '/');
 		$r = new Request($u);
 
@@ -117,25 +117,25 @@ final class ApiRouteTest extends TestCase
 
 	public function testMatchUrlWithBasePath(): void
 	{
-		$route = new ApiRoute('/api/ping', 'U');
+		$route = new ApiRoute(path: '/api/ping', presenter: 'U');
 		$u = new UrlScript('http://foo.com/api-project/api/ping', '/api-project/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
-		$route = new ApiRoute('/api/ping/', 'U');
+		$route = new ApiRoute(path: '/api/ping/', presenter: 'U');
 		$u = new UrlScript('http://foo.com/api-project/api/ping/', '/api-project/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
-		$route = new ApiRoute('/api/ping', 'U');
+		$route = new ApiRoute(path: '/api/ping', presenter: 'U');
 		$u = new UrlScript('http://foo.com/api-project/api/fake', '/api-project/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/api/ping', 'U');
+		$route = new ApiRoute(path: '/api/ping', presenter: 'U');
 		$u = new UrlScript('http://foo.com/api-project/fake', '/api-project/');
 		$r = new Request($u);
 
@@ -144,52 +144,52 @@ final class ApiRouteTest extends TestCase
 
 	public function testMatchParameters(): void
 	{
-		$route = new ApiRoute('/users/<id>', 'U');
+		$route = new ApiRoute(path: '/users/<id>', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users/<id>', 'U');
+		$route = new ApiRoute(path: '/users/<id>', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/aaaa', '/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same('aaaa', $appRq['id']);
 
-		$route = new ApiRoute('/users[/<id>]', 'U');
+		$route = new ApiRoute(path: '/users[/<id>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/aaaa', '/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same('aaaa', $appRq['id']);
 
-		$route = new ApiRoute('/users[/<id>]', 'U');
+		$route = new ApiRoute(path: '/users[/<id>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $appRq = $route->match($r));
 		Assert::same(null, $appRq['id']);
 
-		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
+		$route = new ApiRoute(path: '/users/<l>-<p>[/<id>/<a>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
+		$route = new ApiRoute(path: '/users/<l>-<p>[/<id>/<a>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/a', '/');
 		$r = new Request($u);
 
 		Assert::same(null, $route->match($r));
 
-		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
+		$route = new ApiRoute(path: '/users/<l>-<p>[/<id>/<a>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/l-p', '/');
 		$r = new Request($u);
 
 		Assert::notSame(null, $route->match($r));
 
-		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
+		$route = new ApiRoute(path: '/users/<l>-<p>[/<id>/<a>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/l-p/8/aa', '/');
 		$r = new Request($u);
 
@@ -199,7 +199,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same(8, (int) $appRq['id']);
 		Assert::same('aa', $appRq['a']);
 
-		$route = new ApiRoute('/users/<l>-<p>[/<id>/<a>]', 'U');
+		$route = new ApiRoute(path: '/users/<l>-<p>[/<id>/<a>]', presenter: 'U');
 		$u = new UrlScript('http://foo.com/users/l-p/8/aa?bubla=a', '/');
 		$r = new Request($u);
 
@@ -207,7 +207,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('a', $appRq['bubla']);
 		Assert::same('U', $appRq['presenter']);
 
-		$route = new ApiRoute('/users[/<id>][/<foo>][/<bar>]', 'U');
+		$route = new ApiRoute(path: '/users[/<id>][/<foo>][/<bar>]', presenter: 'U');
 
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
@@ -241,7 +241,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('foo', $appRq['foo']);
 		Assert::same('bar', $appRq['bar']);
 
-		$route = new ApiRoute('/users[/<id>[/<foo>[/<bar>]]]', 'U');
+		$route = new ApiRoute(path: '/users[/<id>[/<foo>[/<bar>]]]', presenter: 'U');
 
 		$u = new UrlScript('http://foo.com/users', '/');
 		$r = new Request($u);
@@ -275,7 +275,7 @@ final class ApiRouteTest extends TestCase
 		Assert::same('foo', $appRq['foo']);
 		Assert::same('bar', $appRq['bar']);
 
-		$route = new ApiRoute('/users[/<id>[/<foo>[/<bar>]]]', 'U');
+		$route = new ApiRoute(path: '/users[/<id>[/<foo>[/<bar>]]]', presenter: 'U');
 		$route->setAutoBasePath(false);
 
 		$u = new UrlScript('http://foo.com/users/1/foo/bar');
@@ -291,25 +291,25 @@ final class ApiRouteTest extends TestCase
 	{
 		$r = (new AppRq('Reources:Users'))->toArray();
 		$u = new UrlScript('http://foo.com/users');
-		$route = new ApiRoute('/users/<id>', 'U');
+		$route = new ApiRoute(path: '/users/<id>', presenter: 'U');
 
 		Assert::same(null, $route->constructUrl($r, $u));
 
 		$r = (new AppRq('Reources:Users', 'GET', ['id' => 8]))->toArray();
 		$u = new UrlScript('http://foo.com/users');
-		$route = new ApiRoute('/users/<id>', 'U');
+		$route = new ApiRoute(path: '/users/<id>', presenter: 'U');
 
 		Assert::same(null, $route->constructUrl($r, $u));
 
 		$r = (new AppRq('Resources:Users', 'GET', ['id' => 8, 'action' => 'create']))->toArray();
 		$u = new UrlScript('http://foo.com/');
-		$route = new ApiRoute('/users/<id>', 'Resources:Users');
+		$route = new ApiRoute(path: '/users/<id>', presenter: 'Resources:Users');
 
 		Assert::same('http://foo.com/users/8', $route->constructUrl($r, $u));
 
 		$r = (new AppRq('Resources:Users', 'GET', ['id' => 8, 'action' => 'create', 'f' => 'a', 'b' => 'a']))->toArray();
 		$u = new UrlScript('http://foo.com/');
-		$route = new ApiRoute('/users/<id>[/<f>-<b>]', 'Resources:Users');
+		$route = new ApiRoute(path: '/users/<id>[/<f>-<b>]', presenter: 'Resources:Users');
 
 		Assert::same('http://foo.com/users/8/a-a', $route->constructUrl($r, $u));
 	}

--- a/tests/Fixtures/UsersController.php
+++ b/tests/Fixtures/UsersController.php
@@ -6,7 +6,7 @@ use Contributte\ApiRouter\ApiRoute;
 use Nette\Application\UI\Presenter;
 
 #[ApiRoute(
-	'/api/users[/<id>]',
+	path: '/api/users[/<id>]',
 	parameters: [
 		'id' => [
 			'requirement' => '\d+',
@@ -21,7 +21,7 @@ class UsersController extends Presenter
 	 * Get user detail
 	 */
 	#[ApiRoute(
-		'/api/users/<id>[/<foo>-<bar>]',
+		path: '/api/users/<id>[/<foo>-<bar>]',
 		parameters: [
 			'id' => [
 				'requirement' => '\d+',

--- a/tests/Fixtures/UsersController.php
+++ b/tests/Fixtures/UsersController.php
@@ -5,33 +5,30 @@ namespace Tests\Fixtures;
 use Contributte\ApiRouter\ApiRoute;
 use Nette\Application\UI\Presenter;
 
-/**
- * @ApiRoute(
- *    "/api/users[/<id>]",
- *    parameters={
- *        "id"={
- *            "requirement": "\d+",
- *            "default": 10
- *        }
- *    }
- * )
- */
+#[ApiRoute(
+	'/api/users[/<id>]',
+	parameters: [
+		'id' => [
+			'requirement' => '\d+',
+			'default' => 10,
+		],
+	],
+)]
 class UsersController extends Presenter
 {
 
 	/**
 	 * Get user detail
-	 *
-	 * @ApiRoute(
-	 *    "/api/users/<id>[/<foo>-<bar>]",
-	 *    parameters={
-	 *        "id"={
-	 *            "requirement": "\d+"
-	 *        }
-	 *    },
-	 *    method="GET"
-	 * )
 	 */
+	#[ApiRoute(
+		'/api/users/<id>[/<foo>-<bar>]',
+		parameters: [
+			'id' => [
+				'requirement' => '\d+',
+			],
+		],
+		method: 'GET',
+	)]
 	public function actionRead(int $id, ?string $foo = null, ?string $bar = null): void
 	{
 		$this->sendJson(['id' => $id, 'foo' => $foo, 'bar' => $bar]);


### PR DESCRIPTION
- Replace @Annotation docblock with #[Attribute] on ApiRoute class
- Update ApiRouterExtension to use ReflectionAttribute instead of Doctrine AnnotationReader
- Remove doctrine/annotations and symfony/cache dependencies
- Update ApiRoute constructor to accept named parameters for attributes
- Update test fixtures and tests to use attribute syntax