### PR TITLE
Fix PHP CodeSniffer configuration error

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Contributte" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<!-- Rulesets -->
-	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml">
+	<rule ref="./vendor/contributte/qa/ruleset-8.2.xml">
 		<exclude name="SlevomatCodingStandard.PHP.DisallowReference.DisallowedPassingByReference"/>
 	</rule>
 


### PR DESCRIPTION
The contributte/qa package no longer provides ruleset-8.0.xml. Updated to ruleset-8.2.xml which matches the project's minimum PHP version requirement (>=8.2).