### PR TITLE
CI: switch coverage reporting to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,6 +13,6 @@ on:
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-coverage.yml@master
+    uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
       php: "8.4"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/api-router/actions"><img src="https://badgen.net/github/checks/contributte/api-router/master"></a>
-  <a href="https://coveralls.io/r/contributte/api-router"><img src="https://badgen.net/coveralls/c/github/contributte/api-router"></a>
+  <a href="https://codecov.io/gh/contributte/api-router"><img src="https://badgen.net/codecov/c/github/contributte/api-router"></a>
   <a href="https://packagist.org/packages/contributte/api-router"><img src="https://badgen.net/packagist/dm/contributte/api-router"></a>
   <a href="https://packagist.org/packages/contributte/api-router"><img src="https://badgen.net/packagist/v/contributte/api-router"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: php-coveralls
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## Summary
- switch the coverage workflow to `nette-tester-coverage-v2`
- replace the README Coveralls badge with Codecov
- remove the obsolete `tests/.coveralls.yml` file

## Related
- contributte/contributte#72