### PR TITLE
Replace phpdbg in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `coverage` Makefile target from `phpdbg` to plain `php` in both CI and local branches.

## Motivation

This repository is part of contributte/contributte#73, which removes `phpdbg` from coverage commands across Contributte repositories.

## Changes

- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification (if applicable)
- `make coverage` currently fails locally because this environment does not have Xdebug, PCOV, or PHPDBG available for code coverage